### PR TITLE
Correct golang multi-arch builds

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,10 +1,15 @@
 # BUILD
-FROM golang:alpine as builder
+# use the build platforms matching arch rather than target arch
+FROM --platform=$BUILDPLATFORM golang:alpine as builder
+
+ARG TARGETARCH
 
 COPY dispatcher.go .
-RUN go build dispatcher.go
+# build for the target arch not the build platform host arch
+RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
+# defaults to using the target arch image
 FROM alpine
 
 EXPOSE 80


### PR DESCRIPTION
Ideally, we want golang to build without QEMU. This PR ensures:
1. the image we build on matches the host platform/architecture
2. the binary we build matches the target run platform
3. the final image we run from matches the architecture of the binary we built