### PR TITLE
Update Dockerfiles (versions) and update guava to resolve CVEs

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,16 +1,14 @@
 # Build stage
-FROM --platform=${BUILDPLATFORM} maven:3-amazoncorretto-17 as build
-WORKDIR /home/lab
-
+FROM --platform=${BUILDPLATFORM} maven:3-amazoncorretto-20 as build
+WORKDIR /usr/local/app
 COPY pom.xml .
 RUN mvn verify -DskipTests --fail-never
-
 COPY src ./src
 RUN mvn verify
 
 # Run stage
-FROM --platform=${TARGETPLATFORM} amazoncorretto:17
-WORKDIR /app
-COPY --from=build /home/lab/target .
-ENTRYPOINT ["java", "-Xmx8m", "-Xms8m", "-jar", "/app/words.jar"]
+FROM --platform=${TARGETPLATFORM} amazoncorretto:20
+WORKDIR /usr/local/app
+COPY --from=build /usr/local/app/target .
+ENTRYPOINT ["java", "-Xmx8m", "-Xms8m", "-jar", "/usr/local/app/words.jar"]
 EXPOSE 8080

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>32.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,19 +1,21 @@
 # BUILD
 # use the build platforms matching arch rather than target arch
 FROM --platform=$BUILDPLATFORM golang:alpine as builder
-
+WORKDIR /usr/local/app
 ARG TARGETARCH
 
 COPY dispatcher.go .
+
 # build for the target arch not the build platform host arch
 RUN GOOS=linux GOARCH=$TARGETARCH go build dispatcher.go
 
 # RUN
 # defaults to using the target arch image
-FROM alpine
+FROM alpine:latest
+WORKDIR /usr/local/app
+
+COPY --from=builder /usr/local/app/dispatcher ./
+COPY static ./static/
 
 EXPOSE 80
-CMD ["/dispatcher"]
-
-COPY --from=builder /go/dispatcher /
-COPY static /static/
+CMD ["/usr/local/app/dispatcher"]


### PR DESCRIPTION
Couple of small updates, including:

- Updating the Java image from `amazoncorretto:17` to `amazoncorretto:20`
- Update guava to resolve CVE
- Use `/usr/local/app` for all working directories, rather than `/` for consistency

Will do more updates later to include cache mounts in the build, run as non-root, etc. Just a few quick and easy updates right now.